### PR TITLE
NODE-4156: support new wallarm_block_page syntax

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -156,6 +156,7 @@ var (
 		"trimSpace":                       strings.TrimSpace,
 		"toUpper":                         strings.ToUpper,
 		"toLower":                         strings.ToLower,
+		"split":                           strings.Split,
 		"formatIP":                        formatIP,
 		"quote":                           quote,
 		"replace":                         replace,

--- a/internal/ingress/defaults/main.go
+++ b/internal/ingress/defaults/main.go
@@ -174,7 +174,7 @@ type Backend struct {
 	// https://docs.wallarm.com/en/admin-en/configure-parameters-en.html#wallarmblockpage
 	WallarmBlockPage string `json:"wallarm-block-page"`
 
-	// This directive lets you set up the page returned to the client when blocking by IP ACL
+	// Deprecated. This directive lets you set up the page returned to the client when blocking by IP ACL
 	// https://docs.wallarm.com/en/admin-en/configure-parameters-en.html#wallarmaclblockpage
 	WallarmAclBlockPage string `json:"wallarm-acl-block-page"`
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1027,11 +1027,12 @@ stream {
             {{ if not (eq $location.Wallarm.Instance "") }}
             wallarm_instance             {{ $location.Wallarm.Instance }};
             {{ end }}
-            {{ if not (eq $location.Wallarm.BlockPage "") }}
-            wallarm_block_page           {{ $location.Wallarm.BlockPage | replace "," " " }};
-            {{ end }}
             {{ if not (eq $location.Wallarm.AclBlockPage "") }}
             wallarm_acl_block_page       {{ $location.Wallarm.AclBlockPage | replace "," " " }};
+            {{ end }}
+            {{ if not (eq $location.Wallarm.BlockPage "") }}
+            {{ range (split $location.Wallarm.BlockPage ";") }}wallarm_block_page {{ . }};
+            {{ end }}
             {{ end }}
             wallarm_parse_response       {{ $location.Wallarm.ParseResponse }};
             wallarm_parse_websocket      {{ $location.Wallarm.ParseWebsocket }};


### PR DESCRIPTION
This change allows to pass multiple sets of values to `wallarm_block_page` annotation separated by `;` symbol.
Example:
`kubectl annotate --overwrite ingress my-ingress nginx.ingress.kubernetes.io/wallarm-block-page="&path/to/page1 type=attack response_code=444;path/to/page2 type=acl_ip,acl_source response_code=555"`

`wallarm_acl_block_page` annotation is now deprecated