### PR TITLE
Add ability to deploy multiple times

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: wallarm-ingress
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.0.2-1
 home: https://github.com/wallarm/ingress
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer with Wallarm module

--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -115,10 +115,10 @@ Create the name of the controller service account to use
 {{- end -}}
 
 {{- define "ingress-nginx.wallarmTarantoolPort" -}}3313{{- end -}}
-{{- define "ingress-nginx.wallarmTarantoolName" -}}{{ .Values.controller.name }}-wallarm-tarantool{{- end -}}
-{{- define "ingress-nginx.wallarmTarantoolCronConfig" -}}{{ template "ingress-nginx.wallarmTarantoolName" . }}-cron{{- end -}}
-{{- define "ingress-nginx.wallarmControllerCronConfig" -}}{{ include "ingress-nginx.controller.fullname" . | lower }}-cron{{- end -}}
-{{- define "ingress-nginx.wallarmSecret" -}}{{ .Values.controller.name }}-secret{{- end -}}
+{{- define "ingress-nginx.wallarmTarantoolName" -}}{{ .Release.Name }}-{{ .Values.controller.name }}-wallarm-tarantool{{- end -}}
+{{- define "ingress-nginx.wallarmTarantoolCronConfig" -}}{{ .Release.Name }}-{{ template "ingress-nginx.wallarmTarantoolName" . }}-cron{{- end -}}
+{{- define "ingress-nginx.wallarmControllerCronConfig" -}}{{ .Release.Name }}-{{ include "ingress-nginx.controller.fullname" . | lower }}-cron{{- end -}}
+{{- define "ingress-nginx.wallarmSecret" -}}{{ .Release.Name }}-{{ .Values.controller.name }}-secret{{- end -}}
 
 {{- define "ingress-nginx.wallarmInitContainer.addNode" -}}
 - name: addnode


### PR DESCRIPTION
Removing hardcoded name of objects allows to install ingress-controller on the same k8s cluster

