### PR TITLE
Feature: ability to use existing secret

### DIFF
--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -222,10 +222,17 @@ Create the name of the controller service account to use
     value: "false"
     {{- end }}
   - name: WALLARM_API_TOKEN
+    {{- if .Values.controller.wallarm.existingSecret.enabled }}
+    valueFrom:
+      secretKeyRef:
+        key: {{ .Values.controller.wallarm.existingSecret.secretKey }}
+        name: {{ .Values.controller.wallarm.existingSecret.secretName }}
+    {{- else if .Values.controller.wallarm.token }}
     valueFrom:
       secretKeyRef:
         key: token
         name: {{ template "ingress-nginx.wallarmSecret" . }}
+    {{- end }} 
   - name: WALLARM_NODE_NAME
     valueFrom:
       fieldRef:
@@ -319,10 +326,17 @@ Create the name of the controller service account to use
     value: "false"
     {{- end }}
   - name: WALLARM_API_TOKEN
+    {{- if .Values.controller.wallarm.existingSecret.enabled }}
+    valueFrom:
+      secretKeyRef:
+        key: {{ .Values.controller.wallarm.existingSecret.secretKey }}
+        name: {{ .Values.controller.wallarm.existingSecret.secretName }}
+    {{- else if .Values.controller.wallarm.token }}
     valueFrom:
       secretKeyRef:
         key: token
         name: {{ template "ingress-nginx.wallarmSecret" . }}
+    {{- end }}
   - name: WALLARM_SYNCNODE_OWNER
     value: www-data
   - name: WALLARM_SYNCNODE_GROUP

--- a/charts/ingress-nginx/templates/controller-wallarm-secret.yaml
+++ b/charts/ingress-nginx/templates/controller-wallarm-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.wallarm.enabled -}}
+{{- if and .Values.controller.wallarm.enabled (not .Values.controller.wallarm.existingSecret.enabled) -}}
 apiVersion: v1
 data:
   token: {{ .Values.controller.wallarm.token | b64enc | quote }}

--- a/charts/ingress-nginx/templates/tarantool-daemonset.yaml
+++ b/charts/ingress-nginx/templates/tarantool-daemonset.yaml
@@ -84,10 +84,17 @@ spec:
             value: "false"
             {{- end }}
           - name: WALLARM_API_TOKEN
+            {{- if .Values.controller.wallarm.existingSecret.enabled }}
+            valueFrom:
+              secretKeyRef:
+                key: {{ .Values.controller.wallarm.existingSecret.secretKey }}
+                name: {{ .Values.controller.wallarm.existingSecret.secretName }}
+            {{- else if .Values.controller.wallarm.token }}
             valueFrom:
               secretKeyRef:
                 key: token
                 name: {{ template "ingress-nginx.wallarmSecret" . }}
+            {{- end }}
           - name: WALLARM_SYNCNODE
             value: "no"
           securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}

--- a/charts/ingress-nginx/templates/tarantool-deployment.yaml
+++ b/charts/ingress-nginx/templates/tarantool-deployment.yaml
@@ -85,10 +85,17 @@ spec:
             value: "false"
             {{- end }}
           - name: WALLARM_API_TOKEN
+            {{- if .Values.controller.wallarm.existingSecret.enabled }}
+            valueFrom:
+              secretKeyRef:
+                key: {{ .Values.controller.wallarm.existingSecret.secretKey }}
+                name: {{ .Values.controller.wallarm.existingSecret.secretName }}
+            {{- else if .Values.controller.wallarm.token }}
             valueFrom:
               secretKeyRef:
                 key: token
                 name: {{ template "ingress-nginx.wallarmSecret" . }}
+            {{- end }}
           - name: WALLARM_SYNCNODE
             value: "no"
           securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -768,6 +768,10 @@ controller:
     apiPort: 443
     apiSSL: true
     token: ""
+    existingSecret:
+      enabled: false
+      secretKey: "token"
+      secretName: "ingress-nginx-wallarm-secret"
     fallback: "on"
     tarantool:
       kind: Deployment


### PR DESCRIPTION
## What this PR does / why we need it:
This PR allows for separation of secret management. Using this approach, the Wallarm token can be provisioned as a k8s secret by the user and doesn't have to be an input value for the chart. The default flag for the newly defined value 'existingSecret' is false, so it won't impact any existing deployments.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
Tested normal functionality of the chart and used External Secrets operator with GCP secret manager to test the new existingSecret functionality.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.
