### PR TITLE
DEVOPS-1839 Additional parameters for Tarantool resources

### DIFF
--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -241,6 +241,8 @@ Create the name of the controller service account to use
     value: www-data
   - name: WALLARM_SYNCNODE_GROUP
     value: www-data
+  - name: WALLARM_INGRESS_CONTROLLER_VERSION
+    value: {{ .Chart.Version | quote }}
   volumeMounts:
   - mountPath: /etc/wallarm
     name: wallarm

--- a/charts/ingress-nginx/templates/tarantool-daemonset.yaml
+++ b/charts/ingress-nginx/templates/tarantool-daemonset.yaml
@@ -72,21 +72,7 @@ spec:
           command: ["/bin/dumb-init", "--"]
           args: ["/opt/wallarm/ruby/usr/share/wallarm-common/syncnode", "-p", "-r", "120", "-l", "STDOUT", "-L", "DEBUG"]
           env:
-          - name: WALLARM_API_HOST
-            value: {{ .Values.controller.wallarm.apiHost | default "api.wallarm.com" }}
-          - name: WALLARM_API_PORT
-            value: {{ .Values.controller.wallarm.apiPort | default "443" | quote }}
-          - name: WALLARM_API_USE_SSL
-            {{- if or (.Values.controller.wallarm.apiSSL) (eq (.Values.controller.wallarm.apiSSL | toString) "<nil>") }}
-            value: "true"
-            {{- else }}
-            value: "false"
-            {{- end }}
-          - name: WALLARM_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                key: token
-                name: {{ template "ingress-nginx.wallarmSecret" . }}
+          {{- include "wallarm.credentials" . | nindent 10 }}
           - name: WALLARM_SYNCNODE
             value: "no"
           securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}

--- a/charts/ingress-nginx/templates/tarantool-daemonset.yaml
+++ b/charts/ingress-nginx/templates/tarantool-daemonset.yaml
@@ -19,6 +19,7 @@ spec:
     matchLabels:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: {{ template "ingress-nginx.wallarmTarantoolName" . }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       labels:
@@ -29,6 +30,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.controller.wallarm.imagePullSecrets | indent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.controller.wallarm.tarantool.terminationGracePeriodSeconds }}
       initContainers:
 {{ include "ingress-nginx.wallarmInitContainer.addNode" . | indent 8 }}
       containers:
@@ -123,6 +125,9 @@ spec:
     {{- if .Values.controller.wallarm.tarantool.affinity }}
       affinity:
 {{ toYaml .Values.controller.wallarm.tarantool.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.wallarm.tarantool.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.controller.wallarm.tarantool.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       volumes:
         - name: wallarm

--- a/charts/ingress-nginx/templates/tarantool-deployment.yaml
+++ b/charts/ingress-nginx/templates/tarantool-deployment.yaml
@@ -20,6 +20,7 @@ spec:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: {{ template "ingress-nginx.wallarmTarantoolName" . }}
   replicas: {{ .Values.controller.wallarm.tarantool.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       labels:
@@ -30,6 +31,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.controller.wallarm.imagePullSecrets | indent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.controller.wallarm.tarantool.terminationGracePeriodSeconds }}
       initContainers:
 {{ include "ingress-nginx.wallarmInitContainer.addNode" . | indent 8 }}
       containers:
@@ -124,6 +126,9 @@ spec:
     {{- if .Values.controller.wallarm.tarantool.affinity }}
       affinity:
 {{ toYaml .Values.controller.wallarm.tarantool.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.wallarm.tarantool.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.controller.wallarm.tarantool.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       volumes:
         - name: wallarm

--- a/charts/ingress-nginx/templates/tarantool-deployment.yaml
+++ b/charts/ingress-nginx/templates/tarantool-deployment.yaml
@@ -73,21 +73,7 @@ spec:
           command: ["/bin/dumb-init", "--"]
           args: ["/opt/wallarm/ruby/usr/share/wallarm-common/syncnode", "-p", "-r", "120", "-l", "STDOUT", "-L", "DEBUG"]
           env:
-          - name: WALLARM_API_HOST
-            value: {{ .Values.controller.wallarm.apiHost | default "api.wallarm.com" }}
-          - name: WALLARM_API_PORT
-            value: {{ .Values.controller.wallarm.apiPort | default "443" | quote }}
-          - name: WALLARM_API_USE_SSL
-            {{- if or (.Values.controller.wallarm.apiSSL) (eq (.Values.controller.wallarm.apiSSL | toString) "<nil>") }}
-            value: "true"
-            {{- else }}
-            value: "false"
-            {{- end }}
-          - name: WALLARM_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                key: token
-                name: {{ template "ingress-nginx.wallarmSecret" . }}
+          {{- include "wallarm.credentials" . | nindent 10 }}
           - name: WALLARM_SYNCNODE
             value: "no"
           securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -786,6 +786,13 @@ controller:
         successThreshold: 1
         timeoutSeconds: 1
       resources: {}
+      terminationGracePeriodSeconds: 30
+      ## Configuration for Tarantool pod assigment
+      affinity: {}
+      tolerations: []
+      topologySpreadConstraints: []
+      nodeSelector:
+        kubernetes.io/os: linux
     heartbeat:
       resources: {}
     wallarm-appstructure:


### PR DESCRIPTION
* Added the following parameters for Tarantool resources:
  - revisionHistoryLimit
  -  terminationGracePeriodSeconds
  -  topologySpreadConstraint 

* Fixed credentials for syncnode container in Tarantool pod
* Added missing env var 'WALLARM_INGRESS_CONTROLLER_VERSION' into addnode container