### PR TITLE
CI: Fix `Build release images` CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,8 +166,8 @@ jobs:
           
           syft -o spdx-json ${IMAGE_NAME} > ${SBOM_SPDX}
           cosign attach sbom --sbom ${SBOM_SPDX} ${IMAGE_DIGEST}
-          cosign sign --key env://COSIGN_PRIVATE_KEY "${IMAGE_URI}.sbom"
-          cosign sign --key env://COSIGN_PRIVATE_KEY ${IMAGE_DIGEST}
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${IMAGE_URI}.sbom"
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${IMAGE_DIGEST}
           
           echo "sbom=${SBOM_SPDX}" >> $GITHUB_OUTPUT
           


### PR DESCRIPTION
Fix `Build release images` CI workflow since braking changes in cosign were introduced