### PR TITLE
DEVOPS-2007: Update default Tarantool arena from 0.2 to 1 Gb

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -756,7 +756,7 @@ controller:
       service:
         annotations: {}
       replicaCount: 1
-      arena: "0.2"
+      arena: "1.0"
       livenessProbe:
         failureThreshold: 3
         initialDelaySeconds: 10


### PR DESCRIPTION
Update default Tarantool arena from 0.2 to 1 Gb